### PR TITLE
CheckOnNonExistingFields

### DIFF
--- a/Contentful.NET/DataModels/Entry.cs
+++ b/Contentful.NET/DataModels/Entry.cs
@@ -93,7 +93,11 @@ namespace Contentful.NET.DataModels
         // to type T
         private T CastPropertyValue<T>(string propertyName)
         {
-            return GetJObject()[propertyName].ToObject<T>();
+            var obj = GetJObject();
+            JToken token;
+            return obj.TryGetValue(propertyName, StringComparison.OrdinalIgnoreCase, out token)
+                ? token.ToObject<T>()
+                : default(T);
         }
 
         // Lazy implementation of the fields JObject. Only deserialized on first usage


### PR DESCRIPTION
When try getting a property (for example non required fields) that's not in the JSON then a nullreferenceException is thrown.