### PR TITLE
Remove back-slashes from full text search operator.

### DIFF
--- a/Contentful.NET/Search/SearchFilterComparer.cs
+++ b/Contentful.NET/Search/SearchFilterComparer.cs
@@ -18,7 +18,7 @@
         internal static readonly SearchFilterComparer GreaterThanEqual = new SearchFilterComparer("\\[gte\\]=");
         internal static readonly SearchFilterComparer LocationNear = new SearchFilterComparer("[near]=");
         internal static readonly SearchFilterComparer LocationWithin = new SearchFilterComparer("[within]=");
-        internal static readonly SearchFilterComparer FullText = new SearchFilterComparer("\\[match\\]=");
+        internal static readonly SearchFilterComparer FullText = new SearchFilterComparer("[match]=");
 
         private SearchFilterComparer(string value)
         {

--- a/KitchenSink/App_Start/UnityConfig.cs
+++ b/KitchenSink/App_Start/UnityConfig.cs
@@ -36,7 +36,8 @@ namespace KitchenSink
             unityContainer.RegisterType<IContentfulClient, ContentfulClient>(
                 new InjectionConstructor(
                     ConfigurationManager.AppSettings["ContentfulAccessToken"], // Access Token
-                    ConfigurationManager.AppSettings["ContentfulSpaceId"] // Space Id
+                    ConfigurationManager.AppSettings["ContentfulSpaceId"], // Space Id
+                    false // Use Preview
                 )
             );
         }


### PR DESCRIPTION
A possible fix for #6.  Was there any particular reason for the backslashes?  Obvs reject if there was.  Tested via the KitchenSink by changing `DogsController.SearchAsync` to use `new FullTextSearchFilter(criteria, "fields.dogType")` and it now doesn't throw the exception.

Also included a fix to the KitchenSink demo.  Was throwing an exception on building up the container.
